### PR TITLE
feat: automatically disable it in production builds

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,8 @@
     ],
     "globals": {
         "Atomics": "readonly",
-        "SharedArrayBuffer": "readonly"
+        "SharedArrayBuffer": "readonly",
+        "__DEV__": "readonly"
     },
     "parserOptions": {
         "ecmaVersion": 2019,
@@ -29,6 +30,7 @@
         }
     },
     "rules": {
+        "no-underscore-dangle": ["error", { "allow": ["__DEV__"] }],
         "import/no-extraneous-dependencies": ["error", {"devDependencies": ["src/__tests__/*"]}],
         "import/extensions": ["error", "never"],
         "@typescript-eslint/consistent-type-assertions": [

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ function component and track properties that changed.
 This is useful if you're building a memoized component but it keeps
 rendering and you want to know the property that is causing that.
 
-It's meant to be used during development, production builds should
-remove it.
+It's meant to be used during development, in production it's automatically disabled.
+
+> Note: Keep in mind that the `__DEV__` global var should be `true` or `process.env.NODE_ENV` should be `production`
 
 ## Example
 

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,0 +1,6 @@
+declare global {
+  // eslint-disable-next-line vars-on-top, no-var
+  var __DEV__: boolean;
+}
+
+export {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,22 @@ const createFormatValue = (
   return jsonFormatValue;
 };
 
+const renderComponent = <T>(
+  component: React.ComponentType<T>,
+  props: Record<string, unknown>,
+): JSX.Element => {
+  if ('children' in props) {
+    const { children, ...regularProps } = props;
+    return React.createElement(
+      component as React.ComponentType<{}>,
+      regularProps,
+      children as React.ReactNode[],
+    );
+  }
+
+  return React.createElement(component as React.ComponentType<{}>, props);
+};
+
 // required so can match, see React.memo()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default <T>(
@@ -116,6 +132,14 @@ export default <T>(
   ): JSX.Element => {
     const props = givenProps as Record<string, unknown>;
     const previousPropsRef = useRef(props as Record<string, unknown>);
+
+    if (
+      (typeof __DEV__ === 'boolean' && !__DEV__) ||
+      process.env.NODE_ENV === 'production'
+    ) {
+      return renderComponent(Component, props);
+    }
+
     if (previousPropsRef.current !== props) {
       const previousProps = previousPropsRef.current;
       const previousPropsKeys = new Set(Object.keys(previousProps));
@@ -145,16 +169,7 @@ export default <T>(
       previousPropsRef.current = props;
     }
 
-    if ('children' in props) {
-      const { children, ...regularProps } = props;
-      return React.createElement(
-        Component as React.ComponentType<{}>,
-        regularProps,
-        children as React.ReactNode[],
-      );
-    }
-
-    return React.createElement(Component as React.ComponentType<{}>, props);
+    return renderComponent(Component, props);
   };
   Wrapper.displayName = `withPropsChangeLogger(${displayName})`;
   return Wrapper;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,11 @@
     "skipLibCheck": true,
     "strict": true,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "es2018"
+    "target": "es2018",
+    "typeRoots" : [
+      "./@types",
+      "./node_modules/@types"
+    ]
   },
   "files": [
     "src/index.ts",


### PR DESCRIPTION


<!-- Open this PR as draft while it is not ready -->

This commit reduces the burden for the developer to remove the HOC, before going to PROD. Having this in mind, it uses the same approach as the prop-types library, where checks are completely disabled.

<!-- Describe what your PR does here, change log, etc -->

## Progress

- [x] Done;

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [x] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [x] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

yarn test
